### PR TITLE
feat: add the minimum height of the about page footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,9 @@
             padding: 0;
             background-color: #f8f9fa;
             color: #343a40;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
         }
 
         header {
@@ -55,7 +58,7 @@
             padding: 15px 0;
             background-color: #563d7c; /* Dark Purple */
             color: white;
-            position: relative;
+            position: absolute;
             bottom: 0;
             width: 100%;
         }


### PR DESCRIPTION
I'm participating in Hacktoberfest 2024 and I saw your site needed to adjust the footer of the about page, so I decided to put a minimum height so as not to depend on the content to be in the right place. I hope you enjoy this contribution and have success with the site :)